### PR TITLE
Phase 1 - Setup Express API scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# orientation-ma

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "orientation-ma-api",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.1.6",
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.2"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+app.use(express.json());
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/', (_req, res) => {
+  res.send('Orientation MA API running');
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a minimal Express + TypeScript scaffold for the API (package.json, tsconfig.json, basic src/index.ts with /health and / routes). This is the Phase 1 setup for the backend.\n\nCloses #1 (if applicable).